### PR TITLE
Added checkbox to invert Mouth Left/Right shapes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -43,6 +43,10 @@ def register():
         name = "Target object(s) to attach the LiveLink stream to",
     )
     bpy.types.Scene.ll_targets_index = bpy.props.IntProperty()
+    bpy.types.Scene.invert_lr_mouth = bpy.props.BoolProperty(
+        name="Invert Mouth L/R",
+        description="Invert MouthLeft-MouthRight blendshapes",
+        default = False)
 
 
 

--- a/bpylivelinkface.py
+++ b/bpylivelinkface.py
@@ -75,6 +75,14 @@ class LiveLinkTarget:
     '''
     def livelink_to_shapekey_idx(self, ll_idx):
         name = LIVE_LINK_FACE_HEADER[ll_idx+2]
+
+        # Invert Mouth Left and Rigth shapes to compensate for LiveLinkFace bug
+        if bpy.context.scene.invert_lr_mouth:
+            if name == 'MouthLeft':
+                name = 'MouthRight'
+            elif name == 'MouthRight':
+                name = 'MouthLeft'
+
         for n in [name, name[0].lower() + name[1:]]:
             idx = self.target.data.shape_keys.key_blocks.find(n)
             if idx != -1:
@@ -88,6 +96,14 @@ class LiveLinkTarget:
 
     def livelink_to_custom_prop(self, ll_idx):
         name = LIVE_LINK_FACE_HEADER[ll_idx+2]
+
+        # Invert Mouth Left and Rigth shapes to compensate for LiveLinkFace bug
+        if bpy.context.scene.invert_lr_mouth:
+            if name == 'MouthLeft':
+                name = 'MouthRight'
+            elif name == 'MouthRight':
+                name = 'MouthLeft'
+                
         for n in [name, name[0].lower() + name[1:]]:
             try:
                 self.target[n]

--- a/operators.py
+++ b/operators.py
@@ -363,6 +363,12 @@ class LiveLinkFacePanel(bpy.types.Panel):
     bl_region_type = "UI"
     bl_options = {"HEADER_LAYOUT_EXPAND"}
 
+    invert_lr_mouth : BoolProperty(
+        name="Invert Mouth L/R",
+        description="Invert MouthLeft-MouthRight blendshapes",
+        default = False
+        )
+
     def draw(self, context):
         box = self.layout.box()
         box.label(text="Target")
@@ -385,4 +391,8 @@ class LiveLinkFacePanel(bpy.types.Panel):
         box = self.layout.box()
         load_csv = box.operator("scene.load_csv_operator")
         
+        box = self.layout.box()
+        box.label(text="Adjustments")
+        row = box.row()
+        box.prop(context.scene, "invert_lr_mouth", text="Invert Mouth L/R")
 


### PR DESCRIPTION
It seems a bug in LiveLinkFace app makes the MouthLeft and MouthRight be incorrectly set.

This MR adds a solution to, by means of a checkbox, compensate for this bug, so when reading data the values are set to the correct blendshape in the mesh.


https://github.com/JRicardoSan/blender_livelinkface/assets/27761857/811d5743-3f57-474b-863b-7d0c27df3278

